### PR TITLE
Kmp crash fix

### DIFF
--- a/KMP.cpp
+++ b/KMP.cpp
@@ -7,14 +7,15 @@ KMP::KMP(std::string given){
 }
 KMP::~KMP(){
 
+    delete[] this->SPTable;
+
 }
 
 void KMP::createSPT(std::string pattern){
     //Create Suffix Prefix table
     //(Keeps track of the index of the largest matching prefix suffix pair in a given pattern based on the index of the pattern at any time)
 
-    int arr[pattern.size()];
-    this->SPTable = &arr[0];
+    this->SPTable = new int[pattern.size()];
 
     //Create iterators to use in table creation
     int i = 0;

--- a/KMP.h
+++ b/KMP.h
@@ -10,7 +10,7 @@ private:
     std::string base;
     int fiRuns = 0;
     int sptRuns = 0;
-    int* SPTable;
+    int* SPTable = new int;
     std::chrono::duration<double> runTime;
 
 public:


### PR DESCRIPTION
Fixed an issue where SPT was losing pointer to array on larger datasets by making it a dynamic array. I did update the deconstructor to match this as well